### PR TITLE
Windows bug fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,16 @@ https://github.com/TejasQ/gen-subs/assets/9947422/bc8df523-b62a-4123-a62d-2df178
 - 🎧 **Multi-modal** - Supports both audio and video files and generates subtitles for each.
 - 📊 **Multi-model** - Choose from a variety of machine learning models ranging from 40MB to >2GB in size. The larger the model, the more accurate the subtitles, but smaller models are also quite capable.
 
+## Installation
+
+To install gen-subs globally, run the following command :
+
+```bash
+npm i -g gen-subs
+```
+
+It's also possible to install it on a per project basis by omitting the -g flag.
+
 ## Usage
 
 You can generate subtitles for any video using the following command:

--- a/actions/for.ts
+++ b/actions/for.ts
@@ -1,4 +1,5 @@
 import { join } from "path";
+import path from "path";
 import { lstat, readdir, writeFile } from "fs/promises";
 import { mkdirp } from "mkdirp";
 import ora from "ora";
@@ -24,7 +25,7 @@ type Options = {
 };
 
 export async function forAction(relativeTarget: string, options: Options) {
-  const target = relativeTarget.startsWith('/') ? relativeTarget : join(process.cwd(), relativeTarget);
+  const target = path.resolve(relativeTarget);
   const { pathWithoutExtension, fileName } = splitFilePath(target);
   const format = (options.format ?? "srt").toLowerCase()
 

--- a/extractAudio.ts
+++ b/extractAudio.ts
@@ -1,14 +1,15 @@
 import ffmpeg from "fluent-ffmpeg";
 import ffmpegInstaller from "@ffmpeg-installer/ffmpeg";
 import { join } from "path";
+import path from "path";
 import { workingDir } from "./util";
 
 ffmpeg.setFfmpegPath(ffmpegInstaller.path);
 
 export function extractAudio(filePath: string): Promise<string> {
   return new Promise((resolve, reject) => {
-    const fileName = filePath.split("/").pop() ?? "";
-    const fileNameWithoutExtension = fileName.split(".")[0];
+    const fileName = path.basename(filePath);
+	const fileNameWithoutExtension = path.basename(filePath , path.extname(fileName));
     const extractedAudioTarget = join(
       workingDir,
       "from-video",

--- a/package.json
+++ b/package.json
@@ -37,10 +37,11 @@
     "inquirer": "^9.2.12",
     "mkdirp": "^3.0.1",
     "ora": "^7.0.1",
+    "rimraf": "^5.0.5",
     "subtitle": "^4.2.1",
+    "typescript": "^5.3.3",
     "vosk": "^0.3.39",
     "wav": "^1.0.2",
-    "rimraf": "^5.0.5",
     "yauzl": "^2.10.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ dependencies:
   subtitle:
     specifier: ^4.2.1
     version: 4.2.1
+  typescript:
+    specifier: ^5.3.3
+    version: 5.3.3
   vosk:
     specifier: ^0.3.39
     version: 0.3.39
@@ -69,7 +72,7 @@ devDependencies:
     version: 3.1.0
   tsup:
     specifier: ^8.0.0
-    version: 8.0.0
+    version: 8.0.0(typescript@5.3.3)
 
 packages:
 
@@ -1894,7 +1897,7 @@ packages:
   /tslib@2.6.2:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
 
-  /tsup@8.0.0:
+  /tsup@8.0.0(typescript@5.3.3):
     resolution: {integrity: sha512-9rOGn8LsFn2iAg2pCB1jnH7ygVuGjlzIomjw0jKXUxAii3iL5cXgm0jZMPKfFH1bSAjQovJ1DUVPSw+oDuIu8A==}
     engines: {node: '>=18'}
     hasBin: true
@@ -1927,6 +1930,7 @@ packages:
       source-map: 0.8.0-beta.0
       sucrase: 3.34.0
       tree-kill: 1.2.2
+      typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
       - ts-node
@@ -1936,6 +1940,11 @@ packages:
     resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
     engines: {node: '>=10'}
     dev: false
+
+  /typescript@5.3.3:
+    resolution: {integrity: sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
 
   /undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}

--- a/processAudio.ts
+++ b/processAudio.ts
@@ -1,13 +1,14 @@
 import ffmpeg from "fluent-ffmpeg";
 import ffmpegInstaller from "@ffmpeg-installer/ffmpeg";
 import { join } from "path";
+import path from "path";
 import { workingDir } from "./util";
 
 ffmpeg.setFfmpegPath(ffmpegInstaller.path);
 
 export function processAudio(inputPath: string): Promise<string> {
-  const fileName = inputPath.split("/").pop() ?? "";
-  const fileNameWithoutExtension = fileName.split(".")[0];
+  const fileName = path.basename(inputPath);
+  const fileNameWithoutExtension = path.basename(inputPath , path.extname(fileName));
   const outputPath = join(
     workingDir, "from-video", `${Date.now()}-${fileNameWithoutExtension}.wav`,
   );

--- a/splitFilePath.ts
+++ b/splitFilePath.ts
@@ -1,6 +1,8 @@
+import path from "path";
+
 export function splitFilePath(filePath: string) {
   // Extract the base name (the last part of the path)
-  const baseName = filePath.split("/").pop();
+  const baseName = path.basename(filePath);;
 
   if (!baseName) throw new Error("Invalid file path");
 


### PR DESCRIPTION
That's a fix for the issue [FFMPEG exits with code 1 - Invalid Argument](https://github.com/TejasQ/gen-subs/issues/8).

It introduces the use of functions from the path module (path.basename(), path.resolve(), path.extname(), ...) for handling file paths correctly for both Windows and POSIX operating systems.
The previous implementation fed file paths with invalid characters sequences when running on Windows which caused the bug.